### PR TITLE
feat(backend): Add support for backend mutation in https://github.com…

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,7 +1,7 @@
 import path from 'path';
 import fs from 'fs';
 
-export const expressPort = process.env.PORT || 3000;
+export const expressPort = process.env.PORT || 4000;
 export const mongoUri = process.env.MONGODB_URI || 'mongodb://localhost:27017/graphql-compose-mongoose';
 export const examplesPath = './examples';
 

--- a/examples/northwind/__tests__/queriesFromIndex.js
+++ b/examples/northwind/__tests__/queriesFromIndex.js
@@ -10,3 +10,7 @@ describe('nortwind > queries', () => {
     });
   });
 });
+
+describe('nortwind > mutations', () => {
+  // not sure how to test this, stub for now
+})

--- a/examples/northwind/auth/herokuSecurity.js
+++ b/examples/northwind/auth/herokuSecurity.js
@@ -1,0 +1,12 @@
+export default function allowOnlyForLocalhost(resolvers) {
+  const secureResolvers = {};
+  Object.keys(resolvers).forEach((k) => {
+    secureResolvers[k] = resolvers[k].wrapResolve(next => (rp) => {
+      if (rp.context.ip === '127.0.0.1' || rp.context.ip === '0:0:0:0:0:0:0:1' || __DEV__ === true) {
+        return next(rp);
+      }
+      throw new Error('For security reason mutation are disabled on Heroku, but will work on your localhost. Please clone https://github.com/nodkz/graphql-compose-examples repo and start server locally.');
+    });
+  });
+  return secureResolvers;
+}

--- a/examples/northwind/graphqlSchema.js
+++ b/examples/northwind/graphqlSchema.js
@@ -58,4 +58,9 @@ const fields = {
 
 ViewerTC.addFields(fields);
 
+GQC.rootMutation().addFields({
+  createProduct: ProductTC.get('$createOne'),
+  removeProductById: ProductTC.get('$removeById'),
+});
+
 export default GQC.buildSchema();

--- a/examples/northwind/graphqlSchema.js
+++ b/examples/northwind/graphqlSchema.js
@@ -17,6 +17,7 @@ import { ProductTC } from './models/product';
 import { RegionTC } from './models/region';
 import { ShipperTC } from './models/shipper';
 import { SupplierTC } from './models/supplier';
+import herokuSecurity from './auth/herokuSecurity';
 
 composeWithRelay(GQC.rootQuery());
 
@@ -59,8 +60,10 @@ const fields = {
 ViewerTC.addFields(fields);
 
 GQC.rootMutation().addFields({
-  createProduct: ProductTC.get('$createOne'),
-  removeProductById: ProductTC.get('$removeById'),
+  ...herokuSecurity({
+    createProduct: ProductTC.get('$createOne'),
+    removeProductById: ProductTC.get('$removeById'),
+  })
 });
 
 export default GQC.buildSchema();

--- a/examples/northwind/models/product.js
+++ b/examples/northwind/models/product.js
@@ -34,7 +34,6 @@ export const Product = mongoose.model('Product', ProductSchema);
 
 export const ProductTC = composeWithRelay(composeWithMongoose(Product));
 
-
 const extendedResolver = ProductTC
   .getResolver('findMany')
   .addFilterArg({


### PR DESCRIPTION
…/nodkz/relay-northwind-app/pull

This change simply exposes the preexisting mutation in graphql-compose-mongoose

Addresses https://github.com/nodkz/relay-northwind-app/issues/1 . Doesn't use the heroku db as that
would be insecure. @nodkz's call here. Perhaps next step is auth ;)